### PR TITLE
rename Pro to OW

### DIFF
--- a/Interface/AddOns/RayUI/mini/BonusRollPreview/BonusRollPreview.lua
+++ b/Interface/AddOns/RayUI/mini/BonusRollPreview/BonusRollPreview.lua
@@ -177,7 +177,7 @@ local function ItemButtonEnter(self)
 	else
 		GameTooltip:Point("TOPLEFT", BonusRollFrame, "BOTTOMLEFT", 0, -2)
 	end
-	GameTooltip:SetItemByID(self.itemID)
+	GameTooltip:SetHyperlink(self.itemLink)
 
 	self:SetScript("OnUpdate", ItemButtonUpdate)
 end

--- a/Interface/AddOns/RayUI/modules/infobar/friend.lua
+++ b/Interface/AddOns/RayUI/modules/infobar/friend.lua
@@ -81,7 +81,6 @@ local function LoadFriend()
 		-- Battle.net Friends
 		for t = 1, BNGetNumFriends() do
 			local presenceID, presenceName, BattleTag, isBattleTagPresence, toonName, toonID, client, isOnline, lastOnline, isAFK, isDND, broadcast, note = BNGetFriendInfo(t)
-
 			-- WoW friends
 			if isOnline then
 				if ( not FriendsTabletData or FriendsTabletData == nil ) then FriendsTabletData = {} end
@@ -122,7 +121,7 @@ local function LoadFriend()
                         )
                     else
                         cname = string.format(
-                            "|cff%02x%02x%02x%s|r |cffcccccc(|r|cff%02x%02x%02x%s|r|cffcccccc)|r",
+                            "|cff%02x%02x%02x%s|r |cffcccccc|r|cff%02x%02x%02x%s|r|cffcccccc|r",
                             FRIENDS_BNET_NAME_COLOR.r * 255, FRIENDS_BNET_NAME_COLOR.g * 255, FRIENDS_BNET_NAME_COLOR.b * 255,
                             presenceName,
                             r * 255, g * 255, b * 255,
@@ -146,6 +145,11 @@ local function LoadFriend()
 					faction = FACTION_ALLIANCE
 				else
                     faction = ""
+                end
+
+                -- Client
+                if client == "Pro" then 
+                	client = "OW"
                 end
 
 				-- Add Friend to list

--- a/Interface/AddOns/RayUI/modules/unitframes/functions.lua
+++ b/Interface/AddOns/RayUI/modules/unitframes/functions.lua
@@ -130,10 +130,7 @@ function UF:ConstructPortrait(frame)
     -- portrait:Point("BOTTOMRIGHT", frame.Health, "BOTTOMRIGHT", 0, 1)
     portrait:SetInside(frame.Health, 1, 1)
     portrait:SetAlpha(.2)
-    portrait.PostUpdate = function(frame)
-        frame:SetCamDistanceScale(1 - 0.01) --Blizzard bug fix
-        frame:SetCamDistanceScale(1)
-    end
+	portrait:SetCamDistanceScale(1)
     if frame.unit and frame.unit:find("boss") then
         portrait.PostUpdate = nil
     end


### PR DESCRIPTION
1. 鼠标悬停在好友按钮上，若好友在守望先锋游戏中，将显示为OW（原来是Pro）
2. 若好友不在wow游戏中，将战网名字后面的括号去掉

不确定你是否喜欢以上改动，喜欢的话就merge上去好了……