### PR TITLE
小号兽王lr的简单监视更改

### DIFF
--- a/Interface/AddOns/RayUI/config/filters/watchers.lua
+++ b/Interface/AddOns/RayUI/config/filters/watchers.lua
@@ -231,7 +231,6 @@ R["Watcher"] = {
                 { spellID = 105919, unitId = "player", caster = "player", filter = "BUFF" },
                 --稳固集中
                 { spellID = 193534, unitId = "player", caster = "player", filter = "BUFF" },
-
                 --野性守護
                 { spellID = 193530, unitId = "player", caster = "player", filter = "BUFF" },
                 --箭雨
@@ -250,9 +249,10 @@ R["Watcher"] = {
                 { spellID = 201081, unitId = "player", caster = "player", filter = "BUFF" },
                 --貓鼬撕咬
                 { spellID = 190931, unitId = "player", caster = "player", filter = "BUFF" },
-
-                --擊殺命令
-                { spellID = 34026, filter = "CD" },
+		--狂野怒火
+                { spellID = 19574, unitId = "player", caster = "player", filter = "BUFF" },
+                --凶暴野兽（杀戮换凶暴应该会好些）
+                { spellID = 120679, filter = "CD" },
             },
             {
                 name = "目标重要buff&debuff",
@@ -262,6 +262,8 @@ R["Watcher"] = {
 
                 --翼龍釘刺
                 { spellID = 19386, unitId = "target", caster = "all", filter = "DEBUFF" },
+		--胁迫
+                { spellID = 24394, unitId = "target", caster = "all", filter = "DEBUFF" },
                 --毒蛇釘刺
                 { spellID = 118253, unitId = "target", caster = "player", filter = "DEBUFF" },
                 --黑鸦
@@ -313,6 +315,10 @@ R["Watcher"] = {
                 { spellID = 131894, filter = "CD" },
                 --强擊
                 { spellID = 193526, filter = "CD" },
+		--狂野怒火
+                { spellID = 19574, filter = "CD" },
+		--野性守护
+                { spellID = 19530, filter = "CD" },
             },
         },
         ["MAGE"] = {


### PR DESCRIPTION
首先原谅我直接网页pull，毕竟只是watchers。
小号可以混工会的H暗夜娱乐团了，现在兽王的核心技能就是凶暴和狂野怒火，在1+1状态下监视杀戮就不太合适了，在狂野前中期安排一个凶暴是可以多打一个杀戮的，重点监视凶暴cd和狂野buff。外加监视了几个大技能cd状况，和胁迫debuff（兽王训犬永远那么蛋疼）。
副本需要WA做辅助监视，插件能让人做的更好。
