### PR TITLE
M4月之姐妹raid框架debuff。

### DIFF
--- a/Interface/AddOns/RayUI/config/filters/raid.lua
+++ b/Interface/AddOns/RayUI/config/filters/raid.lua
@@ -122,15 +122,14 @@ _RaidDebuffsList = {
             [234128] = Defaults(), -- Driven Assault
             -- Sisters of the Moon
             [236603] = Defaults(), -- Rapid Shot
-            [234996] = Defaults(), -- Umbra Suffusion
-            [234995] = Defaults(), -- Lunar Suffusion
-            [236519] = Defaults(), -- Moon Burn
+            [236598] = Defaults(5), -- 急速射击1
+            [236596] = Defaults(5), -- 急速射击2
+            [236519] = Defaults(4), -- Moon Burn
             [236697] = Defaults(), -- Deathly Screech
             [239264] = Defaults(), -- Lunar Flare (Tank)
-            [236712] = Defaults(), -- Lunar Beacon
+            [236712] = Defaults(5), -- Lunar Beacon
             [236304] = Defaults(), -- Incorporeal Shot
             [236550] = Defaults(), -- Discorporate (Tank)
-            [236330] = Defaults(), -- Astral Vulnerability
             [236541] = Defaults(), -- Twilight Glaive
             [233263] = Defaults(), -- Embrace of the Eclipse
             -- Mistress Sassz'ine


### PR DESCRIPTION
删除三个常驻buff，对治疗干扰太大。提高急速射击debuff监控等级。
菜逼团队最好打到46，没进p3，预计修改月光之火和信标的层级。
前三个boss太简单乱打，没有值得修改的debuff