### PR TITLE
fix an iconTexture in alerts.lua

### DIFF
--- a/Interface/AddOns/RayUI/modules/alerts/alerts.lua
+++ b/Interface/AddOns/RayUI/modules/alerts/alerts.lua
@@ -1506,7 +1506,8 @@ end
 
 local function LFGToast_SetUp(isScenario)
     local toast = GetToast("scenario")
-    local name, _, subtypeID, textureFilename, moneyBase, moneyVar, experienceBase, experienceVar, numStrangers, numRewards = GetLFGCompletionReward()
+    -- local name, _, subtypeID, textureFilename, moneyBase, moneyVar, experienceBase, experienceVar, numStrangers, numRewards = GetLFGCompletionReward()
+    local name, _, subtypeID, iconTextureFile, moneyBase, moneyVar, experienceBase, experienceVar, numStrangers, numRewards = GetLFGCompletionReward()
     -- local name, typeID, subtypeID, textureFilename, moneyBase, moneyVar, experienceBase, experienceVar, numStrangers, numRewards =
     -- "The Vortex Pinnacle", 1, 2, "THEVORTEXPINNACLE", 308000, 0, 0, 0, 0, 0
     local money = moneyBase + moneyVar * numStrangers
@@ -1572,7 +1573,8 @@ local function LFGToast_SetUp(isScenario)
     toast.Title:SetText(title)
     toast.Text:SetText(name)
     toast.BG:SetTexture("Interface\\AddOns\\RayUI\\media\\toast-bg-dungeon")
-    toast.Icon:SetTexture("Interface\\LFGFrame\\LFGIcon-"..textureFilename)
+    -- toast.Icon:SetTexture("Interface\\LFGFrame\\LFGIcon-"..textureFilename)
+    toast.Icon:SetTexture(iconTextureFile)
     toast.usedRewards = usedRewards
 
     if isScenario then


### PR DESCRIPTION
当完成地下城时，AlertFrame上的图标显示有误，如图：
![qq 20170823123249](https://user-images.githubusercontent.com/19523197/29598971-3710f50c-87ff-11e7-9cef-cf7d9b71f868.png)
翻了下，在WOW-23910patch7.2.5_PTR里，暴雪修改了......如图：
![qq 20170823124703](https://user-images.githubusercontent.com/19523197/29599465-60bda71c-8802-11e7-947e-9e4d5aeefb6d.png)
